### PR TITLE
list and preview shared charts

### DIFF
--- a/pixiegateway/chartsManager.py
+++ b/pixiegateway/chartsManager.py
@@ -70,4 +70,10 @@ class ChartStorage(Storage):
             walker
         )
 
+    def get_charts(self):
+        return self.fetchMany("""
+                SELECT CHARTID,AUTHOR,DATE,DESCRIPTION,RENDERERID FROM {0}
+            """.format(ChartStorage.CHARTS_TBL_NAME)
+        )
+
 chart_storage = ChartStorage()

--- a/pixiegateway/handlers.py
+++ b/pixiegateway/handlers.py
@@ -151,6 +151,8 @@ class AdminHandler(BaseHandler):
         tab_definitions = OrderedDict([
             ("apps", {"name": "PixieApps", "path": "pixieappList.html", "description": "Published PixieApps",
                       "args": lambda: {"pixieapp_list":NotebookMgr.instance().notebook_pixieapps()}}),
+            ("charts", {"name": "Charts", "path": "chartsList.html", "description": "Shared Charts",
+                      "args": lambda: {"charts_list":chart_storage.get_charts()}}),
             ("stats", {"name": "Kernel Stats", "path": "adminStats.html", "description": "PixieGateway Statistics"})
         ])
         tab_id = tab_id or "apps"

--- a/pixiegateway/template/adminCSS.html
+++ b/pixiegateway/template/adminCSS.html
@@ -84,6 +84,7 @@
     }
     .table a {
         color: darkorange;
+        cursor: pointer;
         font-weight: 500;
     }
     .pd-gateway-charts .popover {

--- a/pixiegateway/template/adminCSS.html
+++ b/pixiegateway/template/adminCSS.html
@@ -9,7 +9,7 @@
         margin: 50px 0 0 0;
     }
     .adminOptions {
-        min-height: calc(100vh - 50px) !important;
+        height: calc(100vh - 50px) !important;
         background-color: #1D3649;
         padding: 50px 0 0 0 !important;
     }
@@ -51,15 +51,20 @@
         color: #888888;
         text-align: right;
     }
+    .admin-content-main {
+        max-height: calc(100vh - 100px);
+        overflow: auto;
+    }
     .pd-gateway-logo {
         text-align: center;
         padding: 25px;
     }
     #contents {
-        padding: 25px;
+        padding: 25px 25px 175px 25px;
     }
     .pd-gateway-list,
-    .pd-gateway-stats {
+    .pd-gateway-stats,
+    .pd-gateway-charts {
         margin: 25px 50px;
     }
     .table > tbody > tr > td,
@@ -80,5 +85,11 @@
     .table a {
         color: darkorange;
         font-weight: 500;
+    }
+    .pd-gateway-charts .popover {
+        min-width: 375px !important;
+    }
+    .pd-gateway-charts .popover .arrow {
+        display: none;
     }
 </style>

--- a/pixiegateway/template/adminConsole.html
+++ b/pixiegateway/template/adminConsole.html
@@ -38,12 +38,14 @@
                 {%end%}
             </div>
 
-            {%include "logo.html"%}
+            <div class="admin-content-main">
+                {%include "logo.html"%}
 
-            <div id="contents">
-                {% set path = tab_definitions[selected_tab_id]['path'] %}
-                {% set args = tab_definitions[selected_tab_id]['args']() if 'args' in tab_definitions[selected_tab_id] else {} %}
-                {% module Template("template/" + path, **args) %}
+                <div id="contents">
+                    {% set path = tab_definitions[selected_tab_id]['path'] %}
+                    {% set args = tab_definitions[selected_tab_id]['args']() if 'args' in tab_definitions[selected_tab_id] else {} %}
+                    {% module Template("template/" + path, **args) %}
+                </div>
             </div>
         </div>
     </div>

--- a/pixiegateway/template/chartsList.html
+++ b/pixiegateway/template/chartsList.html
@@ -1,0 +1,30 @@
+<div class="pd-gateway-charts">
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Renderer</th>
+                <th>Author</th>
+                <th>Description</th>
+                <th>Action</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for c in charts_list%}
+            <tr>
+                <td>{{c['DATE']}}</td>
+                <td>{{c['RENDERERID']}}</td>
+                <td>{{c['AUTHOR']}}</td>
+                <td>{{c['DESCRIPTION']}}</td>
+                <td>
+                    <a target="_blank" href="/chart/{{c['CHARTID']}}" tabindex="0">link</a> | 
+                    <a data-html="true" data-toggle="popover" title="{{c['CHARTID']}}" tabindex="0" 
+                        data-content='<object type="text/html" data="/embed/{{c['CHARTID']}}/300/200" width="300" height="200"></object>'>preview</a>
+                </td>
+            </tr>
+            {% end %}
+        </tbody>
+    </table>
+</div>
+
+{%include "chatsJS.html"%}

--- a/pixiegateway/template/chatsJS.html
+++ b/pixiegateway/template/chatsJS.html
@@ -1,0 +1,9 @@
+<script>
+    var displayStats = {}
+    $( document ).ready(function() {
+        $("[data-toggle=popover]").popover({
+            trigger: 'hover focus',
+            placement: 'left'
+        })
+    })
+</script>


### PR DESCRIPTION
@DTAIEB adds a new menu to the admin console that lists and previews shared charts

<img width="618" alt="screen shot 2017-11-08 at 3 12 35 pm" src="https://user-images.githubusercontent.com/13156555/32572105-9530296c-c497-11e7-88bb-108477be9e40.png">
